### PR TITLE
fix rename unsafe-lifecycles

### DIFF
--- a/src/components/time/DayColumn.js
+++ b/src/components/time/DayColumn.js
@@ -39,7 +39,7 @@ class DayColumn extends React.Component {
     this.clearTimeIndicatorInterval();
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.selectable && !this.props.selectable) this._selectable();
     if (!nextProps.selectable && this.props.selectable)
       this._teardownSelectable();

--- a/src/components/time/TimeGrid.js
+++ b/src/components/time/TimeGrid.js
@@ -25,7 +25,7 @@ export default class TimeGrid extends Component {
     this._scrollRatio = null;
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.calculateScroll();
   }
 
@@ -71,7 +71,7 @@ export default class TimeGrid extends Component {
     //this.checkOverflow()
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const { range, scrollToTime } = this.props;
     // When paginating, reset scroll
     if (

--- a/src/components/time/TimeGutter.js
+++ b/src/components/time/TimeGutter.js
@@ -12,7 +12,7 @@ export default class TimeGutter extends Component {
     this.slotMetrics = TimeSlotUtils.getSlotMetrics({min, max, timeslots, step});
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const { min, max, timeslots, step } = nextProps;
     this.slotMetrics = this.slotMetrics.update({ min, max, timeslots, step });
   }


### PR DESCRIPTION
the react-js unsafe life-cycle methods in use are filling up the console
log with warnings that have been already noticed but that wont go away
unless addressed.

mitigation to ignore the warnings is to prefix with UNSAFE_.

via:

    $ cd src
    $ npx react-codemod rename-unsafe-lifecycles


ref: https://forum.seatable.io/t/warning-componentwillreceiveprops-has-been-renamed/299
ref: https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html