### PR TITLE
fix: remove dead key

### DIFF
--- a/src/components/view-setting.js
+++ b/src/components/view-setting.js
@@ -168,7 +168,6 @@ class ViewSetting extends React.Component {
               <div className="title">{intl.get('Color_From')}</div>
               {this.renderSelector(colorColumnOptions, SETTING_KEY.COLUMN_COLOR)}
             </div>
-            <p className="small text-muted">{intl.get('Calendar_Select_Description')}</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
The Calendar_Select_Description string is not in use.

@freeplant: Another minor PR which I think does not need any or only very little review. I plan to take this into master.