### PR TITLE
local-storage plugin-name prefix for key "selectedCalendarView"

### DIFF
--- a/src/ReactBigCalendar.js
+++ b/src/ReactBigCalendar.js
@@ -6,12 +6,14 @@ import momentLocalizer from './utils/localizers/intl-decorator';
 import { getDtableUuid } from './utils/common';
 import { isValidDateObject } from './utils/dates';
 import { getCollaboratorsName } from './utils/value-format-utils';
-import { CALENDAR_VIEWS, SETTING_KEY } from './constants';
+import { CALENDAR_VIEWS, PLUGIN_NAME, SETTING_KEY } from './constants';
 import TableEvent from './model/event';
 import withDragAndDrop from './addons/dragAndDrop';
 
 import './css/react-big-calendar.css';
 import './addons/dragAndDrop/styles.css';
+
+const LOCALSTORAGE_KEY_SELECTED_CALENDAR_VIEW = `.${PLUGIN_NAME}.selectedCalendarView`;
 
 const DragAndDropCalendar = withDragAndDrop(Calendar);
 
@@ -54,7 +56,7 @@ class ReactBigCalendar extends React.Component {
   }
 
   getSelectedView = () => {
-    let selectedCalendarView = JSON.parse(localStorage.getItem('selectedCalendarView')) || {};
+    let selectedCalendarView = JSON.parse(localStorage.getItem(LOCALSTORAGE_KEY_SELECTED_CALENDAR_VIEW)) || {};
     let { activeTable, activeView } = this.props;
     let dtableUuid = getDtableUuid();
     let key = `${dtableUuid}_${activeTable._id}_${activeView._id}`;
@@ -63,12 +65,12 @@ class ReactBigCalendar extends React.Component {
   }
 
   onSelectView = (view) => {
-    let selectedCalendarView = JSON.parse(localStorage.getItem('selectedCalendarView')) || {};
+    let selectedCalendarView = JSON.parse(localStorage.getItem(LOCALSTORAGE_KEY_SELECTED_CALENDAR_VIEW)) || {};
     let { activeTable, activeView } = this.props;
     let dtableUuid = getDtableUuid();
     let key = `${dtableUuid}_${activeTable._id}_${activeView._id}`;
     selectedCalendarView[key] = view;
-    localStorage.setItem('selectedCalendarView', JSON.stringify(selectedCalendarView));
+    localStorage.setItem(LOCALSTORAGE_KEY_SELECTED_CALENDAR_VIEW, JSON.stringify(selectedCalendarView));
     this.setState({selectedView: view});
   }
 


### PR DESCRIPTION
otherwise the risk to clash settings is pretty high, basically immanent when a -dev version is in use next to the production one.

@freeplant this is a small one, please take a quick look if you would also consider it a bit flawed in the past or if (which I can't say) it was by intention to not use a prefix (e.g. other places outside of the plugin related to this local-storage entry, too).